### PR TITLE
deploy.sh fixes

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -94,17 +94,19 @@ COMMANDS_PATH=$(echo "$CONFIG" | node -e "let input = ''; process.stdin.on('data
 # Set version and type (tag or branch)
 if [[ -n "$TAG" ]]; then
     VERSION=$TAG
-    TYPE=true
+    IS_TAG=true
+    # if it's a tag we want to set BRANCH to false
+    BRANCH=false
 else
     VERSION="$BRANCH-$(date +%Y%m%d%H%M%S)"
-    TYPE=false
+    IS_TAG=false
 fi
 
 # Navigate to commands path and execute deployment scripts
 cd $COMMANDS_PATH
 
 # If release goes well, then deploy.
-if ./app-release -v=$VERSION -t=$TYPE -b=$BRANCH; then
+if ./app-release -v=$VERSION -t=$IS_TAG -b=$BRANCH; then
     # If deploy goes well, then delete old releases (and not this one)
     if ./app-deploy -v=$VERSION; then
         # Go up one layer to "domain"

--- a/deploy.sh
+++ b/deploy.sh
@@ -125,5 +125,11 @@ if ./app-release -v=$VERSION -t=$IS_TAG -b=$BRANCH; then
         for FOLDER in $(ls -tp | grep '/$' | grep -v "^$(basename $CURRENT_RELEASE)/" | tail -n +2); do
             rm -rf "$FOLDER"
         done
+    else
+        echo "❌ app-deploy failed. Please check the logs."
+        exit 1
     fi
+else
+    echo "❌ app-release failed. Please check the logs."
+    exit 1
 fi


### PR DESCRIPTION
## Changes
- Fixes an issue where running deploy.sh with a tag causes a git error (-b=main is passed to app-release, which causes it to fail).
<img width="512" alt="Screen Shot 2024-01-18 at 12 02 07 PM" src="https://github.com/amurrell/deploy-commands/assets/3294460/430f978a-adc9-4cf5-be59-3ff47993c098">

- Fixes an issue where app-release or app-deploy fails but the deploy.sh script thinks the overall process was successful. Happens bc the `if ./app-release` portion swallows the error returned (evals to false instead of stopping script)
<img width="682" alt="Screen Shot 2024-01-18 at 12 00 17 PM" src="https://github.com/amurrell/deploy-commands/assets/3294460/295bfa82-9b66-4c37-bc05-a31a83fb1d23">



