### PR TITLE
WIP - Update permissions for pm2, laravel app-release commands

### DIFF
--- a/laravel-deploy/app-release
+++ b/laravel-deploy/app-release
@@ -199,7 +199,18 @@ sudo chmod 777 "$CURRENT/bootstrap" -R
 sudo mkdir -p "$REPO_ROOT/$LARAVELLOGSFOLDER_LOCATION"
 
 ## Change ownership of the logs folder
-sudo chown $OWNER_USER:$OWNER_GROUP "$REPO_ROOT/$LARAVELLOGSFOLDER_LOCATION"
+# If the logs location has a /, loop through and chown each one
+# Prevents issues with paths like Parent/Logs, `chown` will not change the permissions of Parent
+if [[ $LARAVELLOGSFOLDER_LOCATION == *\/* ]]; then
+    IFS='/' read -ra ADDR <<< "$LARAVELLOGSFOLDER_LOCATION"
+    for i in "${ADDR[@]}"; do
+        # join the path, but there should be no leading slash if it's the first one
+        CUR_LOG_PATH="${CUR_LOG_PATH:+$CUR_LOG_PATH/}$i"
+        sudo chown $OWNER_USER:$OWNER_GROUP "$REPO_ROOT/$CUR_LOG_PATH"
+    done
+else
+    sudo chown $OWNER_USER:$OWNER_GROUP "$REPO_ROOT/$LARAVELLOGSFOLDER_LOCATION"
+fi
 
 ## Change back to the commands directory
 cd $RELEASING_FROM

--- a/laravel-deploy/app-release
+++ b/laravel-deploy/app-release
@@ -196,7 +196,7 @@ sudo chmod 777 "$CURRENT/storage" -R
 sudo chmod 777 "$CURRENT/bootstrap" -R
 
 ## Make Logs Directory
-sudo mkdir -p "$REPO_ROOT/$LARAVELLOGSFOLDER_LOCATION"
+sudo mkdir -m 775 -p "$REPO_ROOT/$LARAVELLOGSFOLDER_LOCATION"
 
 ## Change ownership of the logs folder
 # If the logs location has a /, loop through and chown each one
@@ -207,6 +207,7 @@ if [[ $LARAVELLOGSFOLDER_LOCATION == *\/* ]]; then
         # join the path, but there should be no leading slash if it's the first one
         CUR_LOG_PATH="${CUR_LOG_PATH:+$CUR_LOG_PATH/}$i"
         sudo chown $OWNER_USER:$OWNER_GROUP "$REPO_ROOT/$CUR_LOG_PATH"
+        sudo chmod 775 "$REPO_ROOT/$CUR_LOG_PATH"
     done
 else
     sudo chown $OWNER_USER:$OWNER_GROUP "$REPO_ROOT/$LARAVELLOGSFOLDER_LOCATION"

--- a/pm2-deploy/app-release
+++ b/pm2-deploy/app-release
@@ -148,11 +148,22 @@ fi
 
 REPO_ROOT=$(pwd)
 
-# Add Logs Folder
+# Add logs folder
 sudo mkdir -p "$REPO_ROOT/$APPLOGSFOLDER_LOCATION"
 
 ## Change ownership of the logs folder
-sudo chown $OWNER_USER:$OWNER_GROUP "$REPO_ROOT/$APPLOGSFOLDER_LOCATION"
+# If the logs location has a /, loop through and chown each one
+# Prevents issues with paths like Parent/Logs, `chown` will not change the permissions of Parent
+if [[ $APPLOGSFOLDER_LOCATION == *\/* ]]; then
+    IFS='/' read -ra ADDR <<< "$APPLOGSFOLDER_LOCATION"
+    for i in "${ADDR[@]}"; do
+        # join the path, but there should be no leading slash if it's the first one
+        CUR_LOG_PATH="${CUR_LOG_PATH:+$CUR_LOG_PATH/}$i"
+        sudo chown $OWNER_USER:$OWNER_GROUP "$REPO_ROOT/$CUR_LOG_PATH"
+    done
+else
+    sudo chown $OWNER_USER:$OWNER_GROUP "$REPO_ROOT/$APPLOGSFOLDER_LOCATION"
+fi
 
 # Go into the repo's appfolder, where npm is?
 cd $REPO_ROOT/$APPFOLDER

--- a/pm2-deploy/app-release
+++ b/pm2-deploy/app-release
@@ -149,7 +149,7 @@ fi
 REPO_ROOT=$(pwd)
 
 # Add logs folder
-sudo mkdir -p "$REPO_ROOT/$APPLOGSFOLDER_LOCATION"
+sudo mkdir -m 775 -p "$REPO_ROOT/$APPLOGSFOLDER_LOCATION"
 
 ## Change ownership of the logs folder
 # If the logs location has a /, loop through and chown each one
@@ -160,6 +160,7 @@ if [[ $APPLOGSFOLDER_LOCATION == *\/* ]]; then
         # join the path, but there should be no leading slash if it's the first one
         CUR_LOG_PATH="${CUR_LOG_PATH:+$CUR_LOG_PATH/}$i"
         sudo chown $OWNER_USER:$OWNER_GROUP "$REPO_ROOT/$CUR_LOG_PATH"
+        sudo chmod 775 "$REPO_ROOT/$CUR_LOG_PATH"
     done
 else
     sudo chown $OWNER_USER:$OWNER_GROUP "$REPO_ROOT/$APPLOGSFOLDER_LOCATION"


### PR DESCRIPTION
Updated pm2 & laravel release commands.

Fixed an issue where custom log paths like `DockerLocal/logs` would not have the OWNER_USER:OWNER_GROUP applied at all folder levels.

Caused issues:
- deploy.sh wasn't able to delete old releases
- logrotate on log files would fail bc www-data wasn't able to delete old logs