### PR TITLE
Update workflows for AWS SSM to reuse deployment steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ cd /var/www/yoursite.com/commands
 ./app-deploy -v=1.0.1 -s=my-app-server
 ```
 
-#### Preview: Github Action calls `deploy.sh` script to run the above sequence according to git event (eg. tag release `published` vs branch `push`)
+#### Preview: GitHub Action calls `deploy.sh` script to run the above sequence according to git event (eg. tag release `published` vs branch `push`)
 
 ```bash
 cd ~/
@@ -41,7 +41,7 @@ deploy.sh --repo user/project --tag 1.0.1
 - The `app-release` and `app-deploy` scripts look for sibling custom config files (eg. apprepo, appservername, applogsfolder, env files, etc) to minimize the need for lots of switches and to run the processes.
 - Running custom build, test, reload processes is possible by writing your own scripts: `npm-command.sh` to be called during `app-release`,`test-command.sh` and subsequent `reload-command.sh` to enact if successful test-command in `app-deploy`. Working examples are provided!
 - For simplistic approach, you can use `app-release` interactively and manually execute builds and releases while in your server.
-- Optionally, for automatic deployments via Github Actions - Copy from an (SSH, or AWS-SSM) appropriate workflow template from deploy-commands to your project `.github/workflows/deploy.yml` and setup secrets and variables in github repo settings
+- Optionally, for automatic deployments via GitHub Actions - Copy from an (SSH, or AWS-SSM) appropriate workflow template from deploy-commands to your project `.github/workflows/deploy.yml` and setup secrets and variables in github repo settings
 - `deploy.sh` uses [`deploy.config.json`](#step-2-create-a-deploy-script-on-server) to determine which `/var/www/site.com/commands` to use for the deployment.
 
 ---
@@ -51,9 +51,9 @@ deploy.sh --repo user/project --tag 1.0.1
 - [Installation](#installation)
 - [Usage](#usage) - [Building](#building-a-release---prompted-vs-unprompted) | [Deploying](#deploy-any-release---unprompted-only)
 - [Setup Config Files](#setup-config-files) - [General](#generic-deploy-commands-config) | [PM2](#pm2-deploy-commands-config) | [Laravel](#laravel-deploy-commands-config) | [Wordpress/PHP](#wordpress-deploy-commands-config)
-- [Automated Deployments via Github Actions](#automated-deployments-via-github-actions)
+- [Automated Deployments via GitHub Actions](#automated-deployments-via-github-actions)
 
-  → [Step 1: Copy Workflows & Setup in Github](#step-1-copy-workflows-and-setup-in-github)
+  → [Step 1: Copy Workflows & Setup in GitHub](#step-1-copy-workflows-and-setup-in-github)
 
     - [Option A: SSH Workflow](#option-a) | [Option B: AWS SSM Workflows](#option-b)
 
@@ -93,7 +93,7 @@ To get started, follow these steps:
 
 4. Configure your deployment by adding configuration files. See the [Setup Config Files](#setup-config-files) section for details on configuring your deployment.
 
-5. Utilize Github Actions via Workflows to automate deployments. See the [Automated Deployments via Github Actions](#automated-deployments-via-github-actions) section for details on configuring your deployment.
+5. Utilize GitHub Actions via Workflows to automate deployments. See the [Automated Deployments via GitHub Actions](#automated-deployments-via-github-actions) section for details on configuring your deployment.
 
 [↑ Top](#contents)
 
@@ -330,17 +330,17 @@ Wordpress deployments uses **a releases folder** such that the directory structu
 
 ---
 
-## Automated Deployments via Github Actions
+## Automated Deployments via GitHub Actions
 
 Follow these steps to set up a deployment process via github workflows for your project:
 
-- [Step 1: Copy Workflows & Setup in Github (or AWS)](#step-1-copy-workflows-and-setup-in-github)
+- [Step 1: Copy Workflows & Setup in GitHub (or AWS)](#step-1-copy-workflows-and-setup-in-github)
   - [OPTION A: SSH Workflow](#option-a)
   - [OPTION B: AWS SSM Workflow](#option-b)
 
 - [Step 2: Create a Deploy Script on Server](#step-2-create-a-deploy-script-on-server)
 
-- [Step 3 (Optional): Setup Github Environments for GitHub Deployments](#step-3-optional-setup-github-environments-for-github-deployments)
+- [Step 3 (Optional): Setup GitHub Environments for GitHub Deployments](#step-3-optional-setup-github-environments-for-github-deployments)
 
 Workflows depend on a `deploy.sh` script and `deploy.config.json` file that will being using the `app-release` and `app-deploy` scripts. Be sure to follow that pattern for it to work.
 
@@ -354,7 +354,7 @@ This is the `deploy-commands` file structure convention:
 
 ---
 
-### Step 1: Copy Workflows and Setup in Github
+### Step 1: Copy Workflows and Setup in GitHub
 
 #### OPTION A)
 
@@ -399,7 +399,7 @@ Edit the branches you want to trigger the workflow on. By default, it is set to 
 
 #### OPTION B)
 
-**AWS SSM Workflows: Integrate workflows & Setup IAM, Github Secrets and Github Variables**
+**AWS SSM Workflows: Integrate workflows & Setup IAM, GitHub Secrets and GitHub Variables**
 
 You may not have SSH ports open for security reasons and may be using AWS with SSM - in which case, you can use the `deploy-workflow-aws-ssm-<env:prod|dev>.yml` workflow files instead. Copy them into your site's repository under the `.github/workflows/` directory.
 
@@ -558,8 +558,9 @@ If your server has only 1 env setting, it will not do any branch/tag related che
 
 ---
 
-### Step 3 (Optional): Setup Github Environments for GitHub Deployments
+### Step 3 (Optional): Setup GitHub Environments for GitHub Deployments
 > [!NOTE]
+> To use GitHub deployments on private repos, you need to have at least a Team plan. See GitHub https://github.com/pricing#compare-features
 > If you don't want to track GitHub deployments, you can remove the `deployments` portions from the workflow files in your repo (they use the `bobheadxi/deployments` action) and skip the rest of this section.
 
 GitHub deployments are a great way to track the status of your deployments and to see which commit is currently deployed to your server.

--- a/README.md
+++ b/README.md
@@ -401,7 +401,12 @@ Edit the branches you want to trigger the workflow on. By default, it is set to 
 
 **AWS SSM Workflows: Integrate workflows & Setup IAM, GitHub Secrets and GitHub Variables**
 
-You may not have SSH ports open for security reasons and may be using AWS with SSM - in which case, you can use the `deploy-workflow-aws-ssm-<env:prod|dev>.yml` workflow files instead. Copy them into your site's repository under the `.github/workflows/` directory.
+You may not have SSH ports open for security reasons and may be using AWS with SSM - in which case, you can use the following workflow files instead:
+- `deploy-workflow-aws-ssm-dev.yml`
+- `deploy-workflow-aws-ssm-prod.yml`
+- `deploy-aws-ssm.yml` (this is a shared file that both the above workflows use)
+
+Copy them into your site's repository under the `.github/workflows/` directory.
 
 > [!IMPORTANT]
 > Be sure to review the events that will trigger the workflow. For example, you may want to update the `deploy-workflow-aws-ssm-prod.yml` version to work _either_ `main` branch push OR tag `release` publish as it would be redudant to have both trigger the deployment.

--- a/deploy-aws-ssm.yml
+++ b/deploy-aws-ssm.yml
@@ -1,0 +1,160 @@
+name: Deploy via AWS SSM
+
+on:
+  workflow_call:
+    inputs:
+      AWS_REGION:
+        type: string
+        description: 'AWS Region'
+        required: true
+      INSTANCE_ID:
+        type: string
+        description: 'EC2 Instance ID'
+        required: true
+      INSTANCE_USER:
+        type: string
+        description: 'EC2 Instance User'
+        required: true
+      # Note:
+      # This needs to be created manually in the repo settings on GitHub
+      # Go to Repo Settings >  Environment -> New Environment
+      GITHUB_DEPLOYMENT_ENV_NAME:
+        type: string
+        description: 'GitHub Deployment Environment Name'
+        required: true
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        description: 'AWS Access Key ID'
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        description: 'AWS Secret Access Key'
+        required: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+
+    - name: Check if AWS CLI is installed
+      run: |
+        if command -v aws &> /dev/null
+        then
+          echo "AWS CLI is already installed"
+          exit 0
+        else
+          echo "AWS CLI is not installed"
+          exit 1
+        fi
+      id: check-aws-cli
+
+    - name: Install AWS CLI
+      if: steps.check-aws-cli.outcome == 'failure'
+      run: |
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+        unzip awscliv2.zip
+        sudo ./aws/install
+        curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb"
+        sudo dpkg -i session-manager-plugin.deb
+
+    # Setup AWS CLI
+    - name: Set up AWS CLI
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ inputs.AWS_REGION }}
+
+    # Create dev deployment on GitHub via bobheadxi/deployments@v1
+    - name: Start Deployment
+      id: deployment
+      uses: bobheadxi/deployments@v1
+      with:
+        step: start
+        token: ${{ secrets.GITHUB_TOKEN }}
+        env: ${{ inputs.GITHUB_DEPLOYMENT_ENV_NAME }}
+
+    # Send command via AWS SSM
+    - name: Execute Command on Instance
+      id: ssm
+      run: |
+        REF_NAME=$(basename ${{ github.ref }})
+
+        if [ "${{ github.event_name }}" == "push" ]; then
+            COMMAND="./deploy.sh --repo ${{ github.repository }} --branch $REF_NAME"
+        elif [ "${{ github.event_name }}" == "release" ]; then
+            COMMAND="./deploy.sh --repo ${{ github.repository }} --tag $REF_NAME"
+        fi
+
+        # wrap COMMAND so that ubuntu can run it. We are root
+        RUN_AS_COMMAND="sudo -u ${{ inputs.INSTANCE_USER}} -i bash -c \"$COMMAND\""
+        # escape double quotes
+        RUN_AS_COMMAND=${RUN_AS_COMMAND//\"/\\\"}
+        echo "Executing command: $RUN_AS_COMMAND"
+
+        command_id=$(aws ssm send-command \
+            --document-name 'AWS-RunShellScript' \
+            --parameters "{\"commands\": [\"$RUN_AS_COMMAND\"]}" \
+            --instance-ids "${{ inputs.INSTANCE_ID }}" \
+            --output text \
+            --query Command.CommandId)
+
+        # Wait for command to finish - but ignore errors
+        set +e
+        aws ssm wait command-executed \
+            --command-id "${command_id}" \
+            --instance-id "${{ inputs.INSTANCE_ID }}"
+        # return to normal error handling
+        set -e
+
+        while [ $(aws ssm list-commands --command-id $command_id --query "Commands[].Status" --output text) == "InProgress" ]; do
+            sleep 5
+        done
+
+        # Check exit code
+        exit_code=$(aws ssm list-command-invocations \
+            --command-id "${command_id}" \
+            --instance-id "${{ inputs.INSTANCE_ID }}" \
+            --query "CommandInvocations[].StatusDetails" \
+            --output text)
+
+        # Get standard output
+        echo "📝 AWS Command ID [${command_id}] - Standard Output:"
+        aws ssm get-command-invocation \
+            --command-id "${command_id}" \
+            --instance-id "${{ inputs.INSTANCE_ID }}" \
+            --query "StandardOutputContent" \
+            --output text \
+            --no-cli-pager
+
+        # Get standard error
+        echo "📝 AWS Command ID [${command_id}] - Standard Error:"
+        # Get error output
+        aws ssm get-command-invocation \
+            --command-id "${command_id}" \
+            --instance-id "${{ inputs.INSTANCE_ID }}" \
+            --query "StandardErrorContent" \
+            --output text \
+            --no-cli-pager
+
+        # Printf the command link to be helpful
+        echo "👀 AWS Console - Output command link: https://${{ inputs.AWS_REGION }}.console.aws.amazon.com/systems-manager/run-command/${command_id}/${{ inputs.INSTANCE_ID }}"
+
+        # Now report on exit code and exit properly.
+        if [ "$exit_code" = "Success" ]; then
+            echo "✅ Deploy Succeeded"
+        else
+            echo "❌ Deploy Failed"
+            exit 1
+        fi
+
+    - name: Update deployment status
+      uses: bobheadxi/deployments@v1
+      if: always()
+      with:
+        step: finish
+        token: ${{ secrets.GITHUB_TOKEN }}
+        status: ${{ job.status }}
+        env: ${{ steps.deployment.outputs.env }}
+        deployment_id: ${{ steps.deployment.outputs.deployment_id }}

--- a/deploy-workflow-aws-ssm-dev.yml
+++ b/deploy-workflow-aws-ssm-dev.yml
@@ -1,4 +1,4 @@
-name: Deploy via AWS SSM
+name: Deploy Dev via AWS SSM
 
 on:
   push:
@@ -7,131 +7,13 @@ on:
 
 jobs:
   deploy-dev:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v2
+    uses: ./.github/workflows/deploy-aws-ssm.yml
+    with:
+      AWS_REGION: ${{ vars.DEV_AWS_REGION }}
+      INSTANCE_ID: ${{ vars.DEV_INSTANCE_ID }}
+      INSTANCE_USER: ${{ vars.DEV_INSTANCE_USER }}
+      GITHUB_DEPLOYMENT_ENV_NAME: development
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.DEV_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}
 
-    - name: Check if AWS CLI is installed
-      run: |
-        if command -v aws &> /dev/null
-        then
-          echo "AWS CLI is already installed"
-          exit 0
-        else
-          echo "AWS CLI is not installed"
-          exit 1
-        fi
-      id: check-aws-cli
-
-    - name: Install AWS CLI
-      if: steps.check-aws-cli.outcome == 'failure'
-      run: |
-        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-        unzip awscliv2.zip
-        sudo ./aws/install
-        curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb"
-        sudo dpkg -i session-manager-plugin.deb
-
-    # Setup AWS CLI
-    - name: Set up AWS CLI
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        aws-access-key-id: ${{ secrets.DEV_AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ vars.DEV_AWS_REGION }}
-
-    # Create dev deployment on GitHub via bobheadxi/deployments@v1
-    - name: Start Deployment
-      id: deployment
-      uses: bobheadxi/deployments@v1
-      with:
-        step: start
-        token: ${{ secrets.GITHUB_TOKEN }}
-        # This needs to be created manually in the repo settings on GitHub
-        # Go to Repo Settings >  Environment -> New Environment
-        env: development
-
-    # Send command via AWS SSM
-    - name: Execute Command on Instance
-      id: ssm
-      run: |
-        REF_NAME=$(basename ${{ github.ref }})
-
-        if [ "${{ github.event_name }}" == "push" ]; then
-            COMMAND="./deploy.sh --repo ${{ github.repository }} --branch $REF_NAME"
-        elif [ "${{ github.event_name }}" == "release" ]; then
-            COMMAND="./deploy.sh --repo ${{ github.repository }} --tag $REF_NAME"
-        fi
-
-        # wrap COMMAND so that ubuntu can run it. We are root
-        RUN_AS_COMMAND="sudo -u ${{ vars.DEV_INSTANCE_USER}} -i bash -c \"$COMMAND\""
-        # escape double quotes
-        RUN_AS_COMMAND=${RUN_AS_COMMAND//\"/\\\"}
-        echo "Executing command: $RUN_AS_COMMAND"
-
-        command_id=$(aws ssm send-command \
-            --document-name 'AWS-RunShellScript' \
-            --parameters "{\"commands\": [\"$RUN_AS_COMMAND\"]}" \
-            --instance-ids "${{ vars.DEV_INSTANCE_ID }}" \
-            --output text \
-            --query Command.CommandId)
-
-        # Wait for command to finish - but ignore errors
-        set +e
-        aws ssm wait command-executed \
-            --command-id "${command_id}" \
-            --instance-id "${{ vars.DEV_INSTANCE_ID }}"
-        # return to normal error handling
-        set -e
-
-        while [ $(aws ssm list-commands --command-id $command_id --query "Commands[].Status" --output text) == "InProgress" ]; do
-            sleep 5
-        done
-
-        # Check exit code
-        exit_code=$(aws ssm list-command-invocations \
-            --command-id "${command_id}" \
-            --instance-id "${{ vars.DEV_INSTANCE_ID }}" \
-            --query "CommandInvocations[].StatusDetails" \
-            --output text)
-
-        # Get standard output
-        echo "📝 AWS Command ID [${command_id}] - Standard Output:"
-        aws ssm get-command-invocation \
-            --command-id "${command_id}" \
-            --instance-id "${{ vars.DEV_INSTANCE_ID }}" \
-            --query "StandardOutputContent" \
-            --output text \
-            --no-cli-pager
-
-        # Get standard error
-        echo "📝 AWS Command ID [${command_id}] - Standard Error:"
-        # Get error output
-        aws ssm get-command-invocation \
-            --command-id "${command_id}" \
-            --instance-id "${{ vars.DEV_INSTANCE_ID }}" \
-            --query "StandardErrorContent" \
-            --output text \
-            --no-cli-pager
-
-        # Printf the command link to be helpful
-        echo "👀 AWS Console - Output command link: https://${{ vars.DEV_AWS_REGION}}.console.aws.amazon.com/systems-manager/run-command/${command_id}/${{ vars.DEV_INSTANCE_ID }}"
-
-        # Now report on exit code and exit properly.
-        if [ "$exit_code" = "Success" ]; then
-            echo "✅ Deploy Succeeded"
-        else
-            echo "❌ Deploy Failed"
-            exit 1
-        fi
-
-    - name: Update deployment status
-      uses: bobheadxi/deployments@v1
-      if: always()
-      with:
-        step: finish
-        token: ${{ secrets.GITHUB_TOKEN }}
-        status: ${{ job.status }}
-        env: ${{ steps.deployment.outputs.env }}
-        deployment_id: ${{ steps.deployment.outputs.deployment_id }}

--- a/deploy-workflow-aws-ssm-prod.yml
+++ b/deploy-workflow-aws-ssm-prod.yml
@@ -1,4 +1,4 @@
-name: Deploy via AWS SSM
+name: Deploy Prod via AWS SSM
 
 on:
   release:
@@ -7,131 +7,12 @@ on:
 
 jobs:
   deploy-prod:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v2
-
-    - name: Check if AWS CLI is installed
-      run: |
-        if command -v aws &> /dev/null
-        then
-          echo "AWS CLI is already installed"
-          exit 0
-        else
-          echo "AWS CLI is not installed"
-          exit 1
-        fi
-      id: check-aws-cli
-
-    - name: Install AWS CLI
-      if: steps.check-aws-cli.outcome == 'failure'
-      run: |
-        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-        unzip awscliv2.zip
-        sudo ./aws/install
-        curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb"
-        sudo dpkg -i session-manager-plugin.deb
-
-    # Setup AWS CLI
-    - name: Set up AWS CLI
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        aws-access-key-id: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ vars.PROD_AWS_REGION }}
-
-    # Create deployment on GitHub via bobheadxi/deployments@v1
-    - name: Start Deployment
-      id: deployment
-      uses: bobheadxi/deployments@v1
-      with:
-        step: start
-        token: ${{ secrets.GITHUB_TOKEN }}
-        # This needs to be created manually in the repo settings on GitHub
-        # Go to Repo Settings >  Environment -> New Environment
-        env: production
-
-    # Send command via AWS SSM
-    - name: Execute Command on Instance
-      id: ssm
-      run: |
-        REF_NAME=$(basename ${{ github.ref }})
-
-        if [ "${{ github.event_name }}" == "push" ]; then
-            COMMAND="./deploy.sh --repo ${{ github.repository }} --branch $REF_NAME"
-        elif [ "${{ github.event_name }}" == "release" ]; then
-            COMMAND="./deploy.sh --repo ${{ github.repository }} --tag $REF_NAME"
-        fi
-
-        # wrap COMMAND so that ubuntu can run it. We are root
-        RUN_AS_COMMAND="sudo -u ${{ vars.PROD_INSTANCE_USER}} -i bash -c \"$COMMAND\""
-        # escape double quotes
-        RUN_AS_COMMAND=${RUN_AS_COMMAND//\"/\\\"}
-        echo "Executing command: $RUN_AS_COMMAND"
-
-        command_id=$(aws ssm send-command \
-            --document-name 'AWS-RunShellScript' \
-            --parameters "{\"commands\": [\"$RUN_AS_COMMAND\"]}" \
-            --instance-ids "${{ vars.PROD_INSTANCE_ID }}" \
-            --output text \
-            --query Command.CommandId)
-
-        # Wait for command to finish - but ignore errors
-        set +e
-        aws ssm wait command-executed \
-            --command-id "${command_id}" \
-            --instance-id "${{ vars.PROD_INSTANCE_ID }}"
-        # return to normal error handling
-        set -e
-
-        while [ $(aws ssm list-commands --command-id $command_id --query "Commands[].Status" --output text) == "InProgress" ]; do
-            sleep 5
-        done
-
-        # Check exit code
-        exit_code=$(aws ssm list-command-invocations \
-            --command-id "${command_id}" \
-            --instance-id "${{ vars.PROD_INSTANCE_ID }}" \
-            --query "CommandInvocations[].StatusDetails" \
-            --output text)
-
-        # Get standard output
-        echo "📝 AWS Command ID [${command_id}] - Standard Output:"
-        aws ssm get-command-invocation \
-            --command-id "${command_id}" \
-            --instance-id "${{ vars.PROD_INSTANCE_ID }}" \
-            --query "StandardOutputContent" \
-            --output text \
-            --no-cli-pager
-
-        # Get standard error
-        echo "📝 AWS Command ID [${command_id}] - Standard Error:"
-        # Get error output
-        aws ssm get-command-invocation \
-            --command-id "${command_id}" \
-            --instance-id "${{ vars.PROD_INSTANCE_ID }}" \
-            --query "StandardErrorContent" \
-            --output text \
-            --no-cli-pager
-
-        # Printf the command link to be helpful
-        echo "👀 AWS Console - Output command link: https://${{ vars.PROD_AWS_REGION}}.console.aws.amazon.com/systems-manager/run-command/${command_id}/${{ vars.PROD_INSTANCE_ID }}"
-
-        # Now report on exit code and exit properly.
-        if [ "$exit_code" = "Success" ]; then
-            echo "✅ Deploy Succeeded"
-        else
-            echo "❌ Deploy Failed"
-            exit 1
-        fi
-
-    - name: Update deployment status
-      uses: bobheadxi/deployments@v1
-      if: always()
-      with:
-        step: finish
-        token: ${{ secrets.GITHUB_TOKEN }}
-        status: ${{ job.status }}
-        env: ${{ steps.deployment.outputs.env }}
-        deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+    uses: ./.github/workflows/deploy-aws-ssm.yml
+    with:
+      AWS_REGION: ${{ vars.PROD_AWS_REGION }}
+      INSTANCE_ID: ${{ vars.PROD_INSTANCE_ID }}
+      INSTANCE_USER: ${{ vars.PROD_INSTANCE_USER }}
+      GITHUB_DEPLOYMENT_ENV_NAME: production
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Changes:
- Update Readme with disclaimer about needing paid plan to use GitHub deployment statuses
- Update AWS SSM deployments to reuse a shared workflow file with the common steps. It takes in inputs and secrets that are passed from the calling workflow.

Since the diff is a bit hard to parse, here's a screenshot that shows what the changes to the steps are (changes from var -> inputs, etc):
![Screen Shot 2024-05-29 at 1 07 17 PM](https://github.com/amurrell/deploy-commands/assets/3294460/d4208acc-2ca6-41ef-86b5-77e6d2bcaaaa)
